### PR TITLE
Snyk has created this PR to upgrade strip-ansi from 6.0.0 to 7.1.0.

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -45,7 +45,7 @@
     "lodash.sortby": "^4.7.0",
     "ora": "5.4.0",
     "p-map": "^4.0.0",
-    "strip-ansi": "6.0.0",
+    "strip-ansi": "7.1.0",
     "toml": "3.0.0"
   },
   "repository": {


### PR DESCRIPTION
This PR has been opened to make sure our repositories are kept up-to-date. It updates strip-ansi from version 6.0.0 to version 7.1.0. Review relevant docs for possible breaking changes. 


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["package_name","package_from","package_to"],"fieldsUsed":["commitMessage","description","title"],"templateUrl":"https://app.dev.snyk.io/rest/groups/4753625c-e8dd-4368-85f6-471854a161b0/settings/pull_request_template?version=2024-05-08"},"dependencies":[{"name":"strip-ansi","from":"6.0.0","to":"7.1.0"}],"env":"dev","hasFixes":false,"isBreakingChange":true,"isMajorUpgrade":true,"issuesToFix":[],"prId":"232354bd-fadd-40a3-bb77-fc2fdcc82700","prPublicId":"232354bd-fadd-40a3-bb77-fc2fdcc82700","packageManager":"npm","priorityScoreList":[],"projectPublicId":"df1884fd-d592-4bc9-9aca-f065573169e2","projectUrl":"https://app.dev.snyk.io/org/testorgcristina/project/df1884fd-d592-4bc9-9aca-f065573169e2?utm_source=github&utm_medium=referral&page=upgrade-pr","prType":"upgrade","templateFieldSources":{"branchName":"default","commitMessage":"group","description":"group","title":"group"},"templateVariants":["custom"],"type":"auto","upgrade":[],"upgradeInfo":{"versionsDiff":4,"publishedDate":"2023-05-28T09:55:04.358Z"},"vulns":[]}'